### PR TITLE
feat: add Claude Code plugin marketplace support

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-marketplace.json",
+  "name": "opencli-skill",
+  "owner": {
+    "name": "joeseesun",
+    "url": "https://github.com/joeseesun"
+  },
+  "plugins": [
+    {
+      "name": "opencli",
+      "source": "./",
+      "description": "CLI tool that turns websites into CLI interfaces, reusing Chrome's login state. Supports Bilibili, Zhihu, Twitter/X, YouTube, Weibo, 小红书, V2EX, Reddit, HackerNews, 雪球, BOSS直聘 etc.",
+      "version": "1.0.0"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add `.claude-plugin/marketplace.json` to enable plugin discovery and management through Claude Code's plugin system

## Details
This PR adds the necessary marketplace metadata file that allows this skill to be discovered and managed through Claude Code's built-in plugin marketplace.

Users can now install this skill by:
1. Adding this repo as a marketplace source in settings
2. Using `/plugins` to browse and install

🤖 Generated with [Claude Code](https://claude.com/claude-code)